### PR TITLE
Added option to input OMDB personal API key

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -1,4 +1,4 @@
-API_URL = 'http://www.omdbapi.com/?i=%s&plot=%s&tomatoes=true'
+API_URL = 'http://www.omdbapi.com/?apikey=%s&i=%s&plot=%s&tomatoes=true'
 RE_RUNTIME = Regex('((?P<hours>[0-9]+) hrs? )?(?P<minutes>[0-9]+) min')
 
 def Start():
@@ -54,7 +54,7 @@ class OmdbApi(Agent.Movies):
     else:
       plot = 'full'
 
-    url = API_URL % (metadata.id, plot)
+    url = API_URL % (Prefs['api_key'], metadata.id, plot)
 
     try:
       movie = JSON.ObjectFromURL(url, sleep=5.0)

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -108,5 +108,11 @@
     "label": "Add Rotten Tomatoes rating to summary",
     "type": "bool",
     "default": "false"
+  },
+  {
+    "id": "api_key",
+    "label": "Personal API key",
+    "type": "text",
+    "default": ""
   }
 ]


### PR DESCRIPTION
Here is a fix to allow entering your personal API key. If there is a null entry, there may be problems. Not sure how you want to handle that. Either way, going forward having an API key will be mandatory.